### PR TITLE
Let a group be expanded by when the page is opened

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -65,6 +65,10 @@ Declare a group in the menu. takes on object with the following attributes:
 * `icon`: Icon name from font-awesome. E.g `bug` will use the `fa-bug` class for the icon
 * `order`: The menu is reordered according to this key. This allows to declare menus in different modules, without caring about the module load order.
 
+#### `glMenuServiceProvider.setDefaultGroup(group)`
+
+Declare a group to be the default group. Can be used directly after the `addGroup(group)` call.
+
 #### `glMenuServiceProvider.setFooter(footer_items)`
 
 Declare the menu footer links. The menu contains up to three footer button, that can be used for arbitrary external links. `footer_items` is a list of objects with following attributes:

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
         "npm": ">=1.4.0"
     },
     "devDependencies": {
-        "guanlecoja": "latest",
+        "guanlecoja": "0.7.2",
         "shelljs": "0.5.1"
     }
 }

--- a/src/module/menu_service/menu.service.coffee
+++ b/src/module/menu_service/menu.service.coffee
@@ -1,6 +1,7 @@
 class GlMenu extends Provider
     constructor: ->
         @groups = {}
+        @defaultGroup = null
         @footer = []
 
     appTitle: "set AppTitle using GlMenuServiceProvider.setAppTitle"
@@ -10,6 +11,9 @@ class GlMenu extends Provider
         group.order ?= 99
         @groups[group.name] = group
         return @groups
+
+    setDefaultGroup: (group) ->
+        @defaultGroup = group
 
     setFooter: (footer) ->
         @footer = footer
@@ -47,6 +51,7 @@ class GlMenu extends Provider
         self = @
         return {
             getGroups: -> groups
+            getDefaultGroup: -> self.defaultGroup
             getFooter: -> self.footer
             getAppTitle: -> self.appTitle
         }

--- a/src/module/menu_service/menu.service.spec.coffee
+++ b/src/module/menu_service/menu.service.spec.coffee
@@ -18,11 +18,15 @@ describe 'menuService', ->
                 glMenuServiceProvider.addGroup
                     name: group.name
             else
-                glMenuServiceProvider.addGroup
+                groupForProvider =
                     name: group.name
                     caption: _.capitalize(group.name)
                     icon: group.name
                     order: if i == "edit" then undefined else group.name.length
+                glMenuServiceProvider.addGroup groupForProvider
+                if i == "cab"
+                    glMenuServiceProvider.setDefaultGroup groupForProvider
+                    
 
         glMenuServiceProvider.setFooter [
             caption: "Github"
@@ -49,6 +53,11 @@ describe 'menuService', ->
         expect(groups[0].items.length).toEqual(7)
         expect(namedGroups['bug'].items.length).toEqual(0)
         expect(namedGroups['bug'].caption).toEqual('Bugcab')
+
+    it 'should have the default group set', inject (glMenuService) ->
+        defaultGroup = glMenuService.getDefaultGroup()
+        groups = glMenuService.getGroups()
+        expect(defaultGroup).toEqual(groups[0])
 
     # simple test to make sure the directive loads
     it 'should generate error if group is undefined', ->

--- a/src/module/page_with_sidebar/page_with_sidebar.directive.coffee
+++ b/src/module/page_with_sidebar/page_with_sidebar.directive.coffee
@@ -16,7 +16,7 @@ class _glPageWithSidebar extends Controller
         @groups = glMenuService.getGroups()
         @footer = glMenuService.getFooter()
         @appTitle = glMenuService.getAppTitle()
-        @activeGroup = null
+        @activeGroup = glMenuService.getDefaultGroup()
         @inSidebar = false
         @sidebarActive = @sidebarPinned
 

--- a/src/module/page_with_sidebar/page_with_sidebar.spec.coffee
+++ b/src/module/page_with_sidebar/page_with_sidebar.spec.coffee
@@ -14,6 +14,7 @@ describe 'page with sidebar', ->
             name: 'g2'
         ]
         glMenuService.getGroups = -> groups
+        glMenuService.getDefaultGroup = -> groups[1]
         scope = $rootScope;
         $compile(elmBody)(scope);
         scope.$digest();
@@ -30,10 +31,11 @@ describe 'page with sidebar', ->
         expect(elmBody).toBeDefined()
         g = scope.page.groups[1]
 
-        scope.page.toggleGroup(g)
         expect(scope.page.activeGroup).toBe(g)
         scope.page.toggleGroup(g)
         expect(scope.page.activeGroup).toBe(null)
+        scope.page.toggleGroup(g)
+        expect(scope.page.activeGroup).toBe(g)
 
         scope.page.enterSidebar()
         expect(scope.page.sidebarActive).toBe(true)


### PR DESCRIPTION
Adds `setDefaultGroup(group)` to `glMenuServiceProvider`. This group is then expanded when the page is loaded.

In my company, we want Buildbot's "Builds" submenu to be expanded on page loads, which can be easily solved with this patch.

I have updated the tests and injected my new code into Buildbot to verify that it works as desired.