### PR TITLE
Fix for issue #3657 where angular-bootstrap-ui dialog causing scroll to jump

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -146,6 +146,7 @@ The stored list of notifications.
 
 ## ChangeLog
 
+* 1.8.0: body is no more height:100%, in order to make full height page, user need to use height: 100vh
 * 1.7.0: topbar is now responsive. It will collapse on mobile.
 * 1.6.3: Adds setDefaultGroup(group) to glMenuServiceProvider. This option allows to expand a menu by default
 * 1.6.2: Fix width issues of content which push some content off-screen for certain monitor size

--- a/Readme.md
+++ b/Readme.md
@@ -146,7 +146,8 @@ The stored list of notifications.
 
 ## ChangeLog
 
-* 1.8.0: body is no more height:100%, in order to make full height page, user need to use height: 100vh
+* 1.8.0: body is no more height:100%, in order to make full height page, user need to use height: 100vh.
+         left-bar pinned preference is now stored in the browser.
 * 1.7.0: topbar is now responsive. It will collapse on mobile.
 * 1.6.3: Adds setDefaultGroup(group) to glMenuServiceProvider. This option allows to expand a menu by default
 * 1.6.2: Fix width issues of content which push some content off-screen for certain monitor size

--- a/guanlecoja/config.coffee
+++ b/guanlecoja/config.coffee
@@ -13,7 +13,7 @@ gulp.task "publish", ['default'], ->
     exec "git clone git@github.com:buildbot/guanlecoja-ui.git"
     bower_json =
         name: "guanlecoja-ui"
-        version: "1.7.0"
+        version: "1.8.0"
         main: ["scripts.js", "styles.css", "fonts/*", "img/*"]
         ignore: []
         description: "Sets of widgets and integrated bower dependencies useful for dashboard SPAs"

--- a/src/styles/styles.less
+++ b/src/styles/styles.less
@@ -1,10 +1,6 @@
 /* Base */
   html {
     overflow-y: scroll;
-    height:100%;
-  }
-  body {
-    height:100%;
   }
   .row {
     margin-left: 0;


### PR DESCRIPTION
Fix for issue #3657 where angular-bootstrap-ui dialog was causing the page in the background to scroll back to top, e.g. in the Buildbot Console view when you click on a build, the console table would automatically scroll to the top.