### PR TITLE
Sidebar behaviour improvements

### DIFF
--- a/src/module/menu_service/menu.service.coffee
+++ b/src/module/menu_service/menu.service.coffee
@@ -3,6 +3,8 @@ class GlMenu extends Provider
         @groups = {}
         @defaultGroup = null
         @footer = []
+        @pinnedByDefault = true
+        @pinnedChangedCallback = null # callback for application to detect when user has pinned/unpinned the menu
 
     appTitle: "set AppTitle using GlMenuServiceProvider.setAppTitle"
 
@@ -20,6 +22,12 @@ class GlMenu extends Provider
 
     setAppTitle: (title) ->
         @appTitle = title
+
+    setPinned: (value) ->
+        @pinnedByDefault = value
+
+    setPinnedChangedCallback: (callback) ->
+        @pinnedChangedCallback = callback
 
     $get: ["$state", ($state) ->
         for state in $state.get()[1...]
@@ -54,5 +62,7 @@ class GlMenu extends Provider
             getDefaultGroup: -> self.defaultGroup
             getFooter: -> self.footer
             getAppTitle: -> self.appTitle
+            getPinnedByDefault: -> self.pinnedByDefault
+            getPinnedChangedCallback: -> self.pinnedChangedCallback
         }
     ]

--- a/src/module/menu_service/menu.service.coffee
+++ b/src/module/menu_service/menu.service.coffee
@@ -3,8 +3,6 @@ class GlMenu extends Provider
         @groups = {}
         @defaultGroup = null
         @footer = []
-        @pinnedByDefault = true
-        @pinnedChangedCallback = null # callback for application to detect when user has pinned/unpinned the menu
 
     appTitle: "set AppTitle using GlMenuServiceProvider.setAppTitle"
 

--- a/src/module/menu_service/menu.service.coffee
+++ b/src/module/menu_service/menu.service.coffee
@@ -23,12 +23,6 @@ class GlMenu extends Provider
     setAppTitle: (title) ->
         @appTitle = title
 
-    setPinned: (value) ->
-        @pinnedByDefault = value
-
-    setPinnedChangedCallback: (callback) ->
-        @pinnedChangedCallback = callback
-
     $get: ["$state", ($state) ->
         for state in $state.get()[1...]
             group = state.data.group
@@ -62,7 +56,5 @@ class GlMenu extends Provider
             getDefaultGroup: -> self.defaultGroup
             getFooter: -> self.footer
             getAppTitle: -> self.appTitle
-            getPinnedByDefault: -> self.pinnedByDefault
-            getPinnedChangedCallback: -> self.pinnedChangedCallback
         }
     ]

--- a/src/module/page_with_sidebar/page_with_sidebar.directive.coffee
+++ b/src/module/page_with_sidebar/page_with_sidebar.directive.coffee
@@ -12,13 +12,22 @@ class GlPageWithSidebar extends Directive
 
 class _glPageWithSidebar extends Controller
     constructor: (@$scope, glMenuService, @$timeout, @$window) ->
-        @sidebarPinned = false; # originally used "@$window.innerWidth > 800". Ideally this would be driven off a user setting that remembered whether it was pinned last time
+        @sidebarPinned = glMenuService.getPinnedByDefault();
+        @pinnedChangedCallback = glMenuService.getPinnedChangedCallback();
+        console.log( "_glPageWithSidebar @sidebarPinned", @sidebarPinned )
         @groups = glMenuService.getGroups()
         @footer = glMenuService.getFooter()
         @appTitle = glMenuService.getAppTitle()
         @activeGroup = glMenuService.getDefaultGroup()
         @inSidebar = false
         @sidebarActive = @sidebarPinned
+
+    toggleSidebarPinned: () ->
+        @sidebarPinned=!@sidebarPinned
+        # callback for application to listen to changes in whether the menu is pinned so 
+        #  it can persist this setting.
+        if @pinnedChangedCallback
+            @pinnedChangedCallback(@sidebarPinned)
 
     toggleGroup: (group) ->
         if @activeGroup!=group

--- a/src/module/page_with_sidebar/page_with_sidebar.directive.coffee
+++ b/src/module/page_with_sidebar/page_with_sidebar.directive.coffee
@@ -12,7 +12,7 @@ class GlPageWithSidebar extends Directive
 
 class _glPageWithSidebar extends Controller
     constructor: (@$scope, glMenuService, @$timeout, @$window) ->
-        @sidebarPinned = @$window.innerWidth > 800
+        @sidebarPinned = false; # originally used "@$window.innerWidth > 800". Ideally this would be driven off a user setting that remembered whether it was pinned last time
         @groups = glMenuService.getGroups()
         @footer = glMenuService.getFooter()
         @appTitle = glMenuService.getAppTitle()
@@ -27,7 +27,6 @@ class _glPageWithSidebar extends Controller
             @activeGroup=null
 
     enterSidebar: ->
-        @sidebarActive = true
         @inSidebar = true
 
     hideSidebar: ->

--- a/src/module/page_with_sidebar/page_with_sidebar.directive.coffee
+++ b/src/module/page_with_sidebar/page_with_sidebar.directive.coffee
@@ -12,7 +12,14 @@ class GlPageWithSidebar extends Directive
 
 class _glPageWithSidebar extends Controller
     constructor: (@$scope, glMenuService, @$timeout, @$window) ->
-        @sidebarPinned = @$window.localStorage.sidebarPinned != "false"  # note -- localstorage only stores strings, so converts the bool to a string upon saving it.
+        
+        # by default, pin sidebar only if window is wide enough (collapse by default if narrow)
+        @sidebarPinned = @$window.innerWidth > 800      
+        # If user has previously pinned or unpinned the sidebar, use the saved value from localStorage
+        sidebarWasPinned = @$window.localStorage.sidebarPinned
+        if ( sidebarWasPinned == "true" || sidebarWasPinned == "false" ) # note -- localstorage only stores strings,  converts bools to string.
+            @sidebarPinned = sidebarWasPinned != "false"
+        
         @groups = glMenuService.getGroups()
         @footer = glMenuService.getFooter()
         @appTitle = glMenuService.getAppTitle()

--- a/src/module/page_with_sidebar/page_with_sidebar.directive.coffee
+++ b/src/module/page_with_sidebar/page_with_sidebar.directive.coffee
@@ -12,9 +12,7 @@ class GlPageWithSidebar extends Directive
 
 class _glPageWithSidebar extends Controller
     constructor: (@$scope, glMenuService, @$timeout, @$window) ->
-        @sidebarPinned = glMenuService.getPinnedByDefault();
-        @pinnedChangedCallback = glMenuService.getPinnedChangedCallback();
-        console.log( "_glPageWithSidebar @sidebarPinned", @sidebarPinned )
+        @sidebarPinned = @$window.localStorage.sidebarPinned != "false"  # note -- localstorage only stores strings, so converts the bool to a string upon saving it.
         @groups = glMenuService.getGroups()
         @footer = glMenuService.getFooter()
         @appTitle = glMenuService.getAppTitle()
@@ -24,10 +22,7 @@ class _glPageWithSidebar extends Controller
 
     toggleSidebarPinned: () ->
         @sidebarPinned=!@sidebarPinned
-        # callback for application to listen to changes in whether the menu is pinned so 
-        #  it can persist this setting.
-        if @pinnedChangedCallback
-            @pinnedChangedCallback(@sidebarPinned)
+        @$window.localStorage.sidebarPinned = @sidebarPinned
 
     toggleGroup: (group) ->
         if @activeGroup!=group

--- a/src/module/page_with_sidebar/page_with_sidebar.spec.coffee
+++ b/src/module/page_with_sidebar/page_with_sidebar.spec.coffee
@@ -2,7 +2,7 @@ describe 'page with sidebar', ->
     beforeEach (module("guanlecoja.ui"))
     elmBody = scope = rootScope = null
 
-    injected = ($rootScope, $compile, glMenuService) ->
+    injected = ($rootScope, $compile, glMenuService, $window) ->
         rootScope = $rootScope
         elmBody = angular.element(
           '<gl-page-with-sidebar></gl-page-with-sidebar>'
@@ -13,6 +13,7 @@ describe 'page with sidebar', ->
         ,
             name: 'g2'
         ]
+        $window.localStorage.sidebarPinned = "false"
         glMenuService.getGroups = -> groups
         glMenuService.getDefaultGroup = -> groups[1]
         scope = $rootScope;
@@ -37,15 +38,9 @@ describe 'page with sidebar', ->
         scope.page.toggleGroup(g)
         expect(scope.page.activeGroup).toBe(g)
 
-        # Changed sidebar to activate on mouse-click, so these tests don't apply anymore
-        # scope.page.enterSidebar()
-        # expect(scope.page.sidebarActive).toBe(true)
-        # scope.page.leaveSidebar()
-        # expect(scope.page.sidebarActive).toBe(true)
-        # scope.page.enterSidebar()
-        # expect(scope.page.sidebarActive).toBe(true)
-        # scope.page.leaveSidebar()
-        
+        # sidebar should get binned state from localStorage.sidebarPinned
+        expect(scope.page.sidebarPinned).toBe(false)
+
         $timeout.flush()
         expect(scope.page.sidebarActive).toBe(true)
         scope.page.sidebarPinned = false

--- a/src/module/page_with_sidebar/page_with_sidebar.spec.coffee
+++ b/src/module/page_with_sidebar/page_with_sidebar.spec.coffee
@@ -38,7 +38,7 @@ describe 'page with sidebar', ->
         scope.page.toggleGroup(g)
         expect(scope.page.activeGroup).toBe(g)
 
-        # sidebar should get binned state from localStorage.sidebarPinned
+        # sidebar should get pinned state from localStorage.sidebarPinned
         expect(scope.page.sidebarPinned).toBe(false)
 
         $timeout.flush()

--- a/src/module/page_with_sidebar/page_with_sidebar.spec.coffee
+++ b/src/module/page_with_sidebar/page_with_sidebar.spec.coffee
@@ -37,13 +37,15 @@ describe 'page with sidebar', ->
         scope.page.toggleGroup(g)
         expect(scope.page.activeGroup).toBe(g)
 
-        scope.page.enterSidebar()
-        expect(scope.page.sidebarActive).toBe(true)
-        scope.page.leaveSidebar()
-        expect(scope.page.sidebarActive).toBe(true)
-        scope.page.enterSidebar()
-        expect(scope.page.sidebarActive).toBe(true)
-        scope.page.leaveSidebar()
+        # Changed sidebar to activate on mouse-click, so these tests don't apply anymore
+        # scope.page.enterSidebar()
+        # expect(scope.page.sidebarActive).toBe(true)
+        # scope.page.leaveSidebar()
+        # expect(scope.page.sidebarActive).toBe(true)
+        # scope.page.enterSidebar()
+        # expect(scope.page.sidebarActive).toBe(true)
+        # scope.page.leaveSidebar()
+        
         $timeout.flush()
         expect(scope.page.sidebarActive).toBe(true)
         scope.page.sidebarPinned = false

--- a/src/module/page_with_sidebar/page_with_sidebar.tpl.jade
+++ b/src/module/page_with_sidebar/page_with_sidebar.tpl.jade
@@ -5,7 +5,7 @@
                 a(href='javascript:')
                     | {{page.appTitle}}
                     span.menu-icon.fa.fa-bars(ng-hide="page.sidebarActive", ng-click='page.sidebarActive=!page.sidebarActive')
-                    span.menu-icon.fa.fa-thumb-tack(ng-show="page.sidebarActive", ng-click="page.sidebarPinned=!page.sidebarPinned", ng-class="{'fa-45': !page.sidebarPinned}")
+                    span.menu-icon.fa.fa-thumb-tack(ng-show="page.sidebarActive", ng-click="page.toggleSidebarPinned()", ng-class="{'fa-45': !page.sidebarPinned}")
             li.sidebar-title
                 span NAVIGATION
             div(ng-repeat="group in page.groups")

--- a/src/module/page_with_sidebar/page_with_sidebar.tpl.jade
+++ b/src/module/page_with_sidebar/page_with_sidebar.tpl.jade
@@ -1,5 +1,5 @@
 .gl-page-with-sidebar(ng-class="{'active': page.sidebarActive, 'pinned': page.sidebarPinned}")
-    .sidebar.sidebar-blue(ng-mouseenter='page.enterSidebar()',ng-mouseleave='page.leaveSidebar()')
+    .sidebar.sidebar-blue(ng-mouseenter='page.enterSidebar()',ng-mouseleave='page.leaveSidebar()',ng-click='page.sidebarActive=true')
         ul
             li.sidebar-main
                 a(href='javascript:')


### PR DESCRIPTION
Addressing issue #9 with the following changes: 
* Remember the sidebar's pinned vs. collapsed state by storing it in `window.localStorage`.  Update the state each time the user pins or collapses.  Upon reloading, initialize the pinned state to the old stored value.
* When the sidebar is collapsed, expand it only when clicked on (not upon mouse-enter).  
* Unit test validates that the `localStorage` setting works