### PR TITLE
Adding some information to the package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,21 @@
+{
+    "name": "guanlecoja-ui",
+    "version": "0.8.7",
+    "lockfileVersion": 1,
+    "requires": true,
+    "dependencies": {
+        "@uirouter/angularjs": {
+            "version": "1.0.15",
+            "resolved": "https://registry.npmjs.org/@uirouter/angularjs/-/angularjs-1.0.15.tgz",
+            "integrity": "sha512-qV+fz+OV5WRNNCXfeVO7nEcSSNESXOxLC0lXM9sv+IwTW6gyiynZ2wHP7fP2ETbr20sPxtbFC+kMVLzyiw/yIg==",
+            "requires": {
+                "@uirouter/core": "5.0.17"
+            }
+        },
+        "@uirouter/core": {
+            "version": "5.0.17",
+            "resolved": "https://registry.npmjs.org/@uirouter/core/-/core-5.0.17.tgz",
+            "integrity": "sha512-aJOSpaRbctGw24Mh74sonLwCyskl7KzFz7M0jRDqrd+eHZK6s/xxi4ZSNuGHRy6kF4x7195buQSJEo7u82t+rA=="
+        }
+    }
+}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "guanlecoja-ui",
     "description": "Implements generic application base for angular.js, ui.router and bootstrap3, with less, and coffeescript.",
-    "version": "0.8.7",
+    "version": "1.0.0",
     "license": "MIT",
     "readmeFilename": "Readme.md",
     "engines": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,9 @@
 {
-    "name": "guanlecoja.ui",
+    "name": "guanlecoja-ui",
+    "description": "Implements generic application base for angular.js, ui.router and bootstrap3, with less, and coffeescript.",
+    "version": "0.8.7",
+    "license": "MIT",
+    "readmeFilename": "Readme.md",
     "engines": {
         "node": ">=0.10.0",
         "npm": ">=1.4.0"
@@ -8,5 +12,8 @@
         "guanlecoja": "~0.8.2",
         "gulp": "~3.9.0",
         "shelljs": "0.5.1"
+    },
+    "dependencies": {
+        "@uirouter/angularjs": "^1.0.15"
     }
 }


### PR DESCRIPTION
Added some information to the package.json which is probably needed for publishing to npm.  
* Changed package name from using dot to hyphen (this seems like the standard on npm and it matches the git repo name).  
* Added version number (not sure what's appropriate here so I just stole the current version number that guanlecoja is using).  
* Added @uirouter/angular as a dependency, since that seems to be where the $stateProvider is coming from.  (but, I'm not clear on how this has been able to work without declaring that dependency, is there something else in the buildbot build chain that's pulling uirouter in and so guanlecoja-ui got away without declaring it as a dependency because it just happened to be present in the bundle anyhow?)